### PR TITLE
Inserted apostrophes, delete by UUID

### DIFF
--- a/RelationTrait.php
+++ b/RelationTrait.php
@@ -254,7 +254,7 @@ trait RelationTrait
                         $isCompositePK = (count($relPKAttr) > 1);
                         foreach ($link as $key => $value) {
                             if (isset($this->$value)) {
-                                $array[$key] = $key . ' = ' . $this->$value;
+                                $array[$key] = "$key = '{$this->$value}'";
                             }
                         }
                         $error = !$this->{$data['name']}[0]->deleteAll(implode(' AND ', $array));


### PR DESCRIPTION
Inserted apostrophes to fix deletion by string columns (e.g. UUIDs)