### PR TITLE
fix bug: not deleting multiple relations with int keys

### DIFF
--- a/RelationTrait.php
+++ b/RelationTrait.php
@@ -117,7 +117,7 @@ trait RelationTrait
                                     foreach ($link as $key => $value) {
                                         $relModel->$key = $this->$value;
                                         if ($isManyMany) $notDeletedFK[$key] = $this->$value;
-                                        elseif ($AQ->multiple) $notDeletedFK[$key] = "\"$key\" = '{$this->$value}'";
+                                        elseif ($AQ->multiple) $notDeletedFK[$key] = "$key = '{$this->$value}'";
                                     }
                                     $relSave = $relModel->save();
 


### PR DESCRIPTION
Multiple relations have not been deleted correctly
(multiple relations are only erased from db if all relations are deleted).

The pull request "Fix error on saving relation Model by #31 opened on 28 Feb by redwert" first resolves the issue. But after i applied the commits from this pull request i was facing the same issue with many many relations.
Tracked it down to a problem just with int keys in multiple relations and fixed it.
I don´t have tested this with string keys - of course a general solution wich works with both int and string keys should be implemented in the future.