### PR TITLE
Update RelationTrait.php

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,6 @@ Yii 2 Models add functionality for load with relation (loadAll($POST)), &amp; tr
 [![Join the chat at https://gitter.im/mootensai/yii2-relation-trait](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/mootensai/yii2-relation-trait?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/mootensai/yii2-relation-trait/trend.png)](https://bitdeli.com/free "Bitdeli Badge")
 
-## Support
-
-[![Support via Gratipay](https://cdn.rawgit.com/gratipay/gratipay-badge/2.3.0/dist/gratipay.svg)](https://gratipay.com/mootensai/)
-
-https://www.paypal.me/yohanesc
-
 
 ## Installation
 
@@ -23,13 +17,13 @@ The preferred way to install this extension is through [composer](http://getcomp
 Either run
 
 ```bash
-$ composer require 'mootensai/yii2-relation-trait:dev-master'
+$ composer require 'stesi/yii2-relation-trait:dev-master'
 ```
 
 or add
 
 ```
-"mootensai/yii2-relation-trait": "*"
+"stesi/yii2-relation-trait": "*"
 ```
 
 to the `require` section of your `composer.json` file.

--- a/RelationTrait.php
+++ b/RelationTrait.php
@@ -29,11 +29,11 @@ trait RelationTrait
                     /* @var $relObj ActiveRecord */
                     $isHasMany = is_array($value) && is_array(current($value));
                     $relName = ($isHasMany) ? lcfirst(Inflector::pluralize($key)) : lcfirst($key);
-                    
-                    if (in_array($relName, $skippedRelations) || !array_key_exists($relName,$relData)){
+
+                    if (in_array($relName, $skippedRelations) || !array_key_exists($relName, $relData)) {
                         continue;
                     }
-                    
+
                     $AQ = $this->getRelation($relName);
                     $relModelClass = $AQ->modelClass;
                     $relPKAttr = $relModelClass::primaryKey();
@@ -64,9 +64,6 @@ trait RelationTrait
                             if (array_filter($relPost)) {
                                 /* @var $relObj ActiveRecord */
                                 $relObj = (empty($relPost[$relPKAttr[0]])) ? new $relModelClass : $relModelClass::findOne($relPost[$relPKAttr[0]]);
-                                if (is_null($relObj)) {
-                                    $relObj = new $relModelClass();
-                                }
                                 $relObj->load($relPost, '');
                                 $container[] = $relObj;
                             }
@@ -100,9 +97,6 @@ trait RelationTrait
                         if (in_array($name, $skippedRelations))
                             continue;
 
-                        unset($fields);
-                        $fields = array();
-                        
                         if (!empty($records)) {
                             $AQ = $this->getRelation($name);
                             $link = $AQ->link;
@@ -117,7 +111,7 @@ trait RelationTrait
                                     foreach ($link as $key => $value) {
                                         $relModel->$key = $this->$value;
                                         if ($isManyMany) $notDeletedFK[$key] = $this->$value;
-                                        elseif ($AQ->multiple) $notDeletedFK[$key] = "\"$key\" = '{$this->$value}'";
+                                        elseif ($AQ->multiple) $notDeletedFK[$key] = "$key = '{$this->$value}'";
                                     }
                                     $relSave = $relModel->save();
 
@@ -159,10 +153,11 @@ trait RelationTrait
                                         }
                                         array_push($notIn, $content);
                                         array_push($compiledNotDeletedPK, $notIn);
+                                        $relModel->deleteAll($compiledNotDeletedPK);
                                         try {
                                             $relModel->deleteAll($compiledNotDeletedPK);
                                         } catch (\yii\db\IntegrityException $exc) {
-                                            $this->addError($name, "Data can't be deleted because it's still used by another data.");
+                                            $this->addError($name, \Yii::t('mtrelt', "Data can't be deleted because it's still used by another data."));
                                             $error = true;
                                         }
                                     } else {
@@ -172,7 +167,7 @@ trait RelationTrait
                                             try {
                                                 $relModel->deleteAll($notDeletedFK . ' AND ' . $relPKAttr[0] . " NOT IN ($compiledNotDeletedPK)");
                                             } catch (\yii\db\IntegrityException $exc) {
-                                                $this->addError($name, "Data can't be deleted because it's still used by another data.");
+                                                $this->addError($name, \Yii::t('mtrelt', "Data can't be deleted because it's still used by another data."));
                                                 $error = true;
                                             }
                                         }
@@ -264,7 +259,6 @@ trait RelationTrait
             $error = false;
             $relData = $this->getRelationData();
             foreach ($relData as $data) {
-                $array = [];
                 if ($data['ismultiple']) {
                     $link = $data['link'];
                     if (count($this->{$data['name']})) {
@@ -297,7 +291,7 @@ trait RelationTrait
 
     public function getRelationData()
     {
-         if (!isset($this->autoRelationMethodNameEnabled)) {
+        if (!isset($this->autoRelationMethodNameEnabled)) {
             $ARMethods = get_class_methods('\yii\db\ActiveRecord');
             $modelMethods = get_class_methods('\yii\base\Model');
             $reflection = new \ReflectionClass($this);
@@ -350,24 +344,24 @@ trait RelationTrait
                 }
             }
         } else {
-             foreach ($this->autoRelationMethodNameEnabled as $methodName) {
+            foreach ($this->autoRelationMethodNameEnabled as $methodName) {
 
-                 try {
-                     $rel = call_user_func(array($this, $methodName));
-                     if ($rel instanceof \yii\db\ActiveQuery) {
-                         $name = lcfirst(str_replace('get', '', $methodName));
-                         $stack[$name]['name'] = lcfirst(str_replace('get', '', $methodName));
-                         $stack[$name]['method'] = $methodName;
-                         $stack[$name]['ismultiple'] = $rel->multiple;
-                         $stack[$name]['modelClass'] = $rel->modelClass;
-                         $stack[$name]['link'] = $rel->link;
-                         $stack[$name]['via'] = $rel->via;
-                     }
-                 } catch (\yii\base\ErrorException $exc) {
-                     //if method name can't be called,
-                 }
-             }
-         }
+                try {
+                    $rel = call_user_func(array($this, $methodName));
+                    if ($rel instanceof \yii\db\ActiveQuery) {
+                        $name = lcfirst(str_replace('get', '', $methodName));
+                        $stack[$name]['name'] = lcfirst(str_replace('get', '', $methodName));
+                        $stack[$name]['method'] = $methodName;
+                        $stack[$name]['ismultiple'] = $rel->multiple;
+                        $stack[$name]['modelClass'] = $rel->modelClass;
+                        $stack[$name]['link'] = $rel->link;
+                        $stack[$name]['via'] = $rel->via;
+                    }
+                } catch (\yii\base\ErrorException $exc) {
+                    //if method name can't be called,
+                }
+            }
+        }
         return $stack;
     }
 

--- a/RelationTrait.php
+++ b/RelationTrait.php
@@ -350,23 +350,24 @@ trait RelationTrait
                 }
             }
         } else {
-            foreach ($this->autoRelationMethodNameEnabled as $methodName) {
+             foreach ($this->autoRelationMethodNameEnabled as $methodName) {
 
-                try {
-                    $rel = call_user_func(array($this, $methodName));
-                    if ($rel instanceof \yii\db\ActiveQuery) {
-                        $name = lcfirst(str_replace('get', '', $methodName));
-                        $stack[$name]['name'] = lcfirst(str_replace('get', '', $methodName));
-                        $stack[$name]['method'] = $methodName;
-                        $stack[$name]['ismultiple'] = $rel->multiple;
-                        $stack[$name]['modelClass'] = $rel->modelClass;
-                        $stack[$name]['link'] = $rel->link;
-                        $stack[$name]['via'] = $rel->via;
-                    }
-                } catch (\yii\base\ErrorException $exc) {
-                    //if method name can't be called,
-                }
-        }
+                 try {
+                     $rel = call_user_func(array($this, $methodName));
+                     if ($rel instanceof \yii\db\ActiveQuery) {
+                         $name = lcfirst(str_replace('get', '', $methodName));
+                         $stack[$name]['name'] = lcfirst(str_replace('get', '', $methodName));
+                         $stack[$name]['method'] = $methodName;
+                         $stack[$name]['ismultiple'] = $rel->multiple;
+                         $stack[$name]['modelClass'] = $rel->modelClass;
+                         $stack[$name]['link'] = $rel->link;
+                         $stack[$name]['via'] = $rel->via;
+                     }
+                 } catch (\yii\base\ErrorException $exc) {
+                     //if method name can't be called,
+                 }
+             }
+         }
         return $stack;
     }
 

--- a/RelationTrait.php
+++ b/RelationTrait.php
@@ -297,56 +297,75 @@ trait RelationTrait
 
     public function getRelationData()
     {
-        $ARMethods = get_class_methods('\yii\db\ActiveRecord');
-        $modelMethods = get_class_methods('\yii\base\Model');
-        $reflection = new \ReflectionClass($this);
-        $stack = [];
-        /* @var $method \ReflectionMethod */
-        foreach ($reflection->getMethods() as $method) {
-            if (in_array($method->name, $ARMethods) || in_array($method->name, $modelMethods)) {
-                continue;
-            }
-            if ($method->name === 'bindModels') {
-                continue;
-            }
-            if ($method->name === 'attachBehaviorInternal') {
-                continue;
-            }
-            if ($method->name === 'loadAll') {
-                continue;
-            }
-            if ($method->name === 'saveAll') {
-                continue;
-            }
-            if ($method->name === 'getRelationData') {
-                continue;
-            }
-            if ($method->name === 'getAttributesWithRelatedAsPost') {
-                continue;
-            }
-            if ($method->name === 'getAttributesWithRelated') {
-                continue;
-            }
-            if ($method->name === 'deleteWithRelated') {
-                continue;
-            }
-            if (strpos($method->name, 'get') !== 0) {
-                continue;
-            }
-            try {
-                $rel = call_user_func(array($this, $method->name));
-                if ($rel instanceof \yii\db\ActiveQuery) {
-                    $name = lcfirst(preg_replace('/^get/', '', $method->name));
-                    $stack[$name]['name'] = lcfirst(preg_replace('/^get/', '', $method->name));
-                    $stack[$name]['method'] = $method->name;
-                    $stack[$name]['ismultiple'] = $rel->multiple;
-                    $stack[$name]['modelClass'] = $rel->modelClass;
-                    $stack[$name]['link'] = $rel->link;
-                    $stack[$name]['via'] = $rel->via;
+         if (!isset($this->autoRelationMethodNameEnabled)) {
+            $ARMethods = get_class_methods('\yii\db\ActiveRecord');
+            $modelMethods = get_class_methods('\yii\base\Model');
+            $reflection = new \ReflectionClass($this);
+            $stack = [];
+            /* @var $method \ReflectionMethod */
+            foreach ($reflection->getMethods() as $method) {
+                if (in_array($method->name, $ARMethods) || in_array($method->name, $modelMethods)) {
+                    continue;
                 }
-            } catch (\yii\base\ErrorException $exc) {
-                //if method name can't be called,
+                if ($method->name === 'bindModels') {
+                    continue;
+                }
+                if ($method->name === 'attachBehaviorInternal') {
+                    continue;
+                }
+                if ($method->name === 'loadAll') {
+                    continue;
+                }
+                if ($method->name === 'saveAll') {
+                    continue;
+                }
+                if ($method->name === 'getRelationData') {
+                    continue;
+                }
+                if ($method->name === 'getAttributesWithRelatedAsPost') {
+                    continue;
+                }
+                if ($method->name === 'getAttributesWithRelated') {
+                    continue;
+                }
+                if ($method->name === 'deleteWithRelated') {
+                    continue;
+                }
+                if (strpos($method->name, 'get') === false) {
+                    continue;
+                }
+                try {
+                    $rel = call_user_func(array($this, $method->name));
+                    if ($rel instanceof \yii\db\ActiveQuery) {
+                        $name = lcfirst(str_replace('get', '', $method->name));
+                        $stack[$name]['name'] = lcfirst(str_replace('get', '', $method->name));
+                        $stack[$name]['method'] = $method->name;
+                        $stack[$name]['ismultiple'] = $rel->multiple;
+                        $stack[$name]['modelClass'] = $rel->modelClass;
+                        $stack[$name]['link'] = $rel->link;
+                        $stack[$name]['via'] = $rel->via;
+                    }
+                } catch (\yii\base\ErrorException $exc) {
+                    //if method name can't be called,
+                }
             }
+        } else {
+            foreach ($this->autoRelationMethodNameEnabled as $methodName) {
+
+                try {
+                    $rel = call_user_func(array($this, $methodName));
+                    if ($rel instanceof \yii\db\ActiveQuery) {
+                        $name = lcfirst(str_replace('get', '', $methodName));
+                        $stack[$name]['name'] = lcfirst(str_replace('get', '', $methodName));
+                        $stack[$name]['method'] = $methodName;
+                        $stack[$name]['ismultiple'] = $rel->multiple;
+                        $stack[$name]['modelClass'] = $rel->modelClass;
+                        $stack[$name]['link'] = $rel->link;
+                        $stack[$name]['via'] = $rel->via;
+                    }
+                } catch (\yii\base\ErrorException $exc) {
+                    //if method name can't be called,
+                }
         }
         return $stack;
     }

--- a/RelationTrait.php
+++ b/RelationTrait.php
@@ -7,7 +7,7 @@
  * @since 1.0
  */
 
-namespace mootensai\relation;
+namespace stesi\relation;
 
 use yii\db\ActiveQuery;
 use \yii\db\ActiveRecord;

--- a/composer.json
+++ b/composer.json
@@ -1,27 +1,21 @@
 {
-    "name": "mootensai/yii2-relation-trait",
+    "name": "stesi/yii2-relation-trait",
     "type": "yii2-extension",
     "description": "Yii 2 Models load with relation, & transaction save with relation",
     "keywords": ["Yii2","relation","load","save","transaction","loadwithrelation", "savewithrelation", "related", "saveall", "loadall"],
-    "homepage": "http://github.com/mootensai/yii2-relation-trait",
+    "homepage": "https://github.com/stesi/yii2-relation-trait
     "license": "BSD-3-Clause",
     "support": {
-        "issues": "https://github.com/mootensai/yii2-relation-trait/issues",
-        "source": "https://github.com/mootensai/yii2-relation-trait"
+        "issues": "https://github.com/stesi/yii2-relation-trait/issues",
+        "source": "https://github.com/stesi/yii2-relation-trait"
     },
-    "authors": [
-        {
-            "name": "Yohanes Candrajaya",
-            "email": "moo.tensai@gmail.com"
-        }
-    ],
     "require": {
         "php": ">=5.4.0",
         "yiisoft/yii2": "~2.0"
     },
     "autoload": {
 	"psr-4": {
-	    "mootensai\\relation\\": ""
+	    "stesi\\relation\\": ""
 	}
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "type": "yii2-extension",
     "description": "Yii 2 Models load with relation, & transaction save with relation",
     "keywords": ["Yii2","relation","load","save","transaction","loadwithrelation", "savewithrelation", "related", "saveall", "loadall"],
-    "homepage": "https://github.com/stesi/yii2-relation-trait
+    "homepage": "https://github.com/stesi/yii2-relation-trait",
     "license": "BSD-3-Clause",
     "support": {
         "issues": "https://github.com/stesi/yii2-relation-trait/issues",


### PR DESCRIPTION
Hi mootensay,
we got performance problems with your trait and same issues due to its way to "desume" relations.
We got a little modification:
if you put in the model the following attribute:
public $autoRelationMethodNameEnabled = ['getMethodName1','getMethodName2'];
the method getRelationData() uses only these relation.

If this make sense for you, or if you have a better idea to achieve the same result  we can merge projects

Thanks anyway for your work

Francesco
    
